### PR TITLE
Added missing lodash dependency

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -6,8 +6,6 @@ var q = require('q');
 
 function Request(options){
 	this.options = _.defaults(options || {}, {
-		host: 'localhost',
-		port: 8080,
 		secure: false,
 		timeout: 30 * 1000
 	});
@@ -53,14 +51,18 @@ Request.prototype.makeRequest = function(method, path, params, data){
 	}
 
 	var options = {
-		host: this.options.host,
-		port: this.options.port,
 		path: path,
 		method: method,
 		headers: {
 			'Content-Type': 'application/json'
 		}
 	};
+	if (this.options.socketPath) {
+		options.socketPath = this.options.socketPath;
+	} else {
+		options.host = this.options.host;
+		options.port = this.options.port;
+	}  
 	var req = this.http.request(options, function(res){
 
 		var data = '';

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "url": "https://github.com/seanmcgary/node-fleet/issues"
   },
   "dependencies": {
+    "lodash": "^3.5.0",
     "q": "~1.0.1"
   }
 }


### PR DESCRIPTION
Added an ability to to specify socket instead of host:port since by default fleet daemon binds to `/var/run/fleet.sock`
